### PR TITLE
Fix: Upgrade deprecated `nodejs` runtime version

### DIFF
--- a/cloudformation/sftp_idp.yaml
+++ b/cloudformation/sftp_idp.yaml
@@ -148,7 +148,7 @@ Parameters:
       "Handler": lambda.handler
       "Role":
         "Fn::GetAtt": "LambdaExecutionRole.Arn"
-      "Runtime": "nodejs12.x"
+      "Runtime": "nodejs18.x"
       Environment:
         Variables:
           PUBLIC_BUCKET: !Ref PublicBucket


### PR DESCRIPTION
**Description of changes:**

**Fixes** failing lambda creation due to deprecated runtime. Upgrading to the latest supported `nodejs18.x` version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
