### PR TITLE
Fix failing lambda creation

### DIFF
--- a/cloudformation/main.yaml
+++ b/cloudformation/main.yaml
@@ -21,6 +21,7 @@ Parameters:
   StackId:
     Description: Stack identifier
     Type: String
+     "AllowedPattern" : "[a-zA-Z0-9]+"
 
 Resources:
   PublicBucket:


### PR DESCRIPTION
**Fixes** *Issue https://github.com/aws-samples/transfer-for-sftp-logical-directories/pull/5*


*Description of changes:*

Added StackId as a mandatory parameter(basic validation only) to fix failing lambda creation of `GetUserConfigLambda`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
